### PR TITLE
Rudimentary widget to list publications, with helper utility method to query posts

### DIFF
--- a/lib/class.publication-widget.php
+++ b/lib/class.publication-widget.php
@@ -1,0 +1,108 @@
+<?php
+class publication_archive_widget extends WP_Widget {
+
+	// register the widget
+	public function publication_archive_widget() {
+		$widget_options = array(
+			'classname' => 'publication_archive',
+			'description' => 'Display a list of publications.'
+		);
+		$this->WP_Widget( 'publication_archive_widget', 'Publication Archive Widget' );
+	}
+
+	// display the widget
+	public function widget( $args, $instance ) { 
+		global $post;
+
+		// Get publications to display
+		$query_args = array();
+		
+		/* @TODO SUPPORT THESE LATER	
+		if ( isset( $instance['publication_cat'] ) )
+			$query_args['cat'] = $instance['publication_cat'];
+		if ( isset( $instance['publication_id'] ) )
+			$query_args['id'] = $instance['publication_id'];
+		*/
+		
+		if ( isset( $instance['number'] ) )
+			$query_args['posts_per_page'] = $instance['number'];
+		if ( isset( $instance['order_by'] ) )
+			$query_args['order_by'] = $instance['order_by'];
+		
+		$publications = WP_Publication_Archive::query_publications( $query_args );
+		
+		if ( $publications->have_posts() ) {
+
+			// begin html
+			$output = '';
+			if ( ! empty( $args['before_widget'] ) )
+				$output .= $args['before_widget'];
+			if ( ! empty( $instance['title'] ) )
+				$output .= "<h3 class='widgettitle'>" . $instance['title'] . "</h3>";
+			
+			$output .= "<ul>";
+			
+			while ( $publications->have_posts() ) {
+				$publications->the_post();
+				
+				// We're doing this instad of `get_the_title()` to avoid include '(Download Publication)'
+				$pub_title = $post->post_title; 
+
+				$output .= "<li><a href='" . get_permalink() . "' title='$pub_title'>$pub_title</a></li>";
+			
+			}
+			
+			$output .= "</ul>";
+			
+			if ( ! empty( $args['after_widget'] ) )
+				$output .= $args['after_widget'];
+			
+			echo $output;
+		
+		}
+		
+		wp_reset_query();
+
+	}
+	
+	// build the widget's admin form
+	public function form( $instance ) {
+		$defaults = array(
+			'title' => 'Publication Archive',
+			'number' => 5,
+			'orderby' => 'menu_order'
+		);
+		$instance = wp_parse_args( (array) $instance, $defaults );
+		
+		if ( isset( $instance['title'] ) ) {
+			$title = $instance['title'];
+		} else {
+			$title = '';
+		}
+		$number = $instance['number'];
+		$orderby = $instance['orderby'];
+
+		$output = "<p>" . __( 'Title', 'rli_testimonials' ) . ": <input class='widefat' name='" . $this->get_field_name( 'title' ) . "' type='text' value='" . esc_attr( $title ) . "' /></p>";
+
+		$output .= "<p>" . __( 'Number of publications to display', 'rli_testimonials' ) . ": <input class='widefat' name='" . $this->get_field_name( 'number' ) . "' type='text' value='" . esc_attr( $number ) . "' /> <em class='help'>Leave blank for no limit.</em></p>";
+
+		$output .= "<p>" . __( 'Order by', 'rli_testimonials' ) . ": <select name='" . $this->get_field_name( 'orderby' ) . "'>";
+			$output .= "<option value='menu_order' " . selected( $orderby, 'menu_order', false ) . ">" . __( 'Manual (drag and drop)', 'rli_testimonials' ) . "</option>";
+			$output .= "<option value='date' " . selected( $orderby, 'date', false ) . ">" . __( 'Latest (publish date)', 'rli_testimonials' ) . "</option>";
+		$output .= "</select></p>";
+
+		echo $output;
+	}
+
+	// save widget settings
+	public function update( $new_instance, $old_instance ) {
+		$instance = $old_instance;
+		$instance['title'] = strip_tags( $new_instance['title'] );
+		$instance['number'] = strip_tags( $new_instance['number'] );
+		$instance['orderby'] = strip_tags( $new_instance['orderby'] );
+
+		return $instance;
+	}
+
+
+}

--- a/lib/class.wp-publication-archive.php
+++ b/lib/class.wp-publication-archive.php
@@ -389,5 +389,30 @@ jQuery(document).ready(function() {
 
 		return $title . " (Download Publication)";
 	}
+	
+	/**
+	 * Utility function to return a WP_Query object with Publication posts
+	 */
+	 
+	public static function query_publications( $args ) {
+		$defaults = array(
+			'posts_per_page' => -1,
+			'order' => 'ASC',
+			'orderby' => 'menu_order'
+		);
+		$query_args = wp_parse_args( $args, $defaults );
+		$query_args['post_type'] = 'publication';
+	
+		$results = new WP_Query( $query_args );
+	
+		return $results;		
+	}
+
+	// Register widget
+	public static function register_widget() {
+		register_widget( 'publication_archive_widget' );
+	}
+
+
 }
 ?>

--- a/wp-publication-archive.php
+++ b/wp-publication-archive.php
@@ -40,11 +40,13 @@ update_option( 'wp-publication-archive-core', 2, '', 'no' );
 
 require_once( 'lib/class.wp-publication-archive.php' );
 require_once( 'lib/class.publication-markup.php' );
+require_once( 'lib/class.publication-widget.php' );
 
 add_action( 'init',             array( 'WP_Publication_Archive', 'register_publication' ) );
 add_action( 'init',             array( 'WP_Publication_Archive', 'register_author' ) );
 add_action( 'init',             array( 'WP_Publication_Archive', 'enqueue_scripts_and_styles' ) );
 add_action( 'save_post',        array( 'WP_Publication_Archive', 'save_meta' ) );
+add_action( 'widgets_init',		array( 'WP_Publication_Archive', 'register_widget' ) );
 
 add_filter( 'post_type_link',   array( 'WP_Publication_Archive', 'publication_link' ), 10, 2 );
 add_filter( 'query_vars',       array( 'WP_Publication_Archive', 'query_vars' ) );


### PR DESCRIPTION
The utility method WP_Publication_Archive::query_publications() may need some explanation. It's used by the widget to query publications before a loop. Why not just write that code directly into the widget? Because in time it can be re-used for front-end display elsewhere in the plugin — possibly to rewrite the shortcode's existing rendering code — and it allows third party plugins and templates a convenience method to write their own custom display code. 

If you like this idea, it'll be a more powerful with companion utilities to handles loops, which will accept template callbacks.(Companion utilities will include default templates to be passed as callbacks. Again, this allows third parties a convenient means to modify output for their own purposes in their own theme and plugin contexts.)

I can attack addition of the utilities within the next few days, as this will be useful on some front-burner projects. Using this new code to revise existing front-end display code in the shortcode can happen in time… Along the way, I'll add some filters for even more flexibility. 

… and if this make no sense — because I am admittedly writing quickly in a somewhat brain-fried mode after a long day — hit me up via email or tele and we can chat.
