### PR TITLE
Fixed undefined variable error.

### DIFF
--- a/lib/class.wp-publication-archive-utilities.php
+++ b/lib/class.wp-publication-archive-utilities.php
@@ -144,7 +144,7 @@ class WP_Publication_Archive_Utilities {
 			$output = '';
 		}
 
-		if ( empty( $categories ) && ! $r['hide_if_empty'] && ! empty( $args['show_option_none'] ) ) {
+		if ( empty( $categories ) && ! $args['hide_if_empty'] && ! empty( $args['show_option_none'] ) ) {
 			$args['show_option_none'] = apply_filters( 'list_cats', $args['show_option_none'] );
 			$output .= "\t<option value='-1' selected='selected'>" . $args['show_option_none'] . "</option>\n";
 		}


### PR DESCRIPTION
I ran across the following error while doing some work for Rocket Lift:

`Notice: Undefined variable: r in /var/www/html/wordpress/wp-content/plugins/WP-Publication-Archive/lib/class.wp-publication-archive-utilities.php on line 147`

It appears that the variable name was simply mistyped.
